### PR TITLE
Backend feature-test: CRUD Supplier/Layup/Layer + import/export JSON

### DIFF
--- a/app/Exceptions/ImportConflictException.php
+++ b/app/Exceptions/ImportConflictException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class ImportConflictException extends Exception
+{
+    public function __construct(
+        public array $conflicts,
+        string $message = 'Import conflicts detected.',
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/app/Http/Controllers/CltLayerController.php
+++ b/app/Http/Controllers/CltLayerController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCltLayerRequest;
+use App\Http\Requests\UpdateCltLayerRequest;
+use App\Models\CltLayer;
+use App\Models\CltLayup;
+use App\Models\Supplier;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
+
+class CltLayerController extends Controller
+{
+    public function index(Supplier $supplier, CltLayup $layup): View
+    {
+        $this->authorize('view', $supplier);
+        $this->authorize('view', $layup);
+
+        abort_unless($layup->supplier_id === $supplier->id, 404);
+
+        $layers = $layup->cltLayers()->paginate(20);
+
+        return view('clt_layers.index', compact('supplier', 'layup', 'layers'));
+    }
+
+    public function create(Supplier $supplier, CltLayup $layup): View
+    {
+        $this->authorize('update', $supplier);
+        $this->authorize('update', $layup);
+
+        abort_unless($layup->supplier_id === $supplier->id, 404);
+
+        return view('clt_layers.create', compact('supplier', 'layup'));
+    }
+
+    public function store(StoreCltLayerRequest $request, Supplier $supplier, CltLayup $layup): RedirectResponse
+    {
+        $this->authorize('update', $supplier);
+        $this->authorize('update', $layup);
+
+        abort_unless($layup->supplier_id === $supplier->id, 404);
+
+        $data = $request->validated();
+        if ($layup->cltLayers()->where('layer_order', $data['layer_order'])->exists()) {
+            throw ValidationException::withMessages(['layer_order' => 'This layer order is already used in this layup.']);
+        }
+
+        $layup->cltLayers()->create($data);
+
+        return redirect()->route('suppliers.layups.layers.index', [$supplier, $layup])->with('status', 'Layer created.');
+    }
+
+    public function show(Supplier $supplier, CltLayup $layup, CltLayer $layer): View
+    {
+        $this->authorize('view', $supplier);
+        $this->authorize('view', $layup);
+        $this->authorize('view', $layer);
+
+        abort_unless($layup->supplier_id === $supplier->id && $layer->clt_layup_id === $layup->id, 404);
+
+        return view('clt_layers.show', compact('supplier', 'layup', 'layer'));
+    }
+
+    public function edit(Supplier $supplier, CltLayup $layup, CltLayer $layer): View
+    {
+        $this->authorize('update', $supplier);
+        $this->authorize('update', $layup);
+        $this->authorize('update', $layer);
+
+        abort_unless($layup->supplier_id === $supplier->id && $layer->clt_layup_id === $layup->id, 404);
+
+        return view('clt_layers.edit', compact('supplier', 'layup', 'layer'));
+    }
+
+    public function update(UpdateCltLayerRequest $request, Supplier $supplier, CltLayup $layup, CltLayer $layer): RedirectResponse
+    {
+        $this->authorize('update', $supplier);
+        $this->authorize('update', $layup);
+        $this->authorize('update', $layer);
+
+        abort_unless($layup->supplier_id === $supplier->id && $layer->clt_layup_id === $layup->id, 404);
+
+        $data = $request->validated();
+        if ((int) $data['layer_order'] !== (int) $layer->layer_order
+            && $layup->cltLayers()->where('layer_order', $data['layer_order'])->exists()) {
+            throw ValidationException::withMessages(['layer_order' => 'This layer order is already used in this layup.']);
+        }
+
+        $layer->update($data);
+
+        return redirect()->route('suppliers.layups.layers.show', [$supplier, $layup, $layer])->with('status', 'Layer updated.');
+    }
+
+    public function destroy(Supplier $supplier, CltLayup $layup, CltLayer $layer): RedirectResponse
+    {
+        $this->authorize('update', $supplier);
+        $this->authorize('update', $layup);
+        $this->authorize('delete', $layer);
+
+        abort_unless($layup->supplier_id === $supplier->id && $layer->clt_layup_id === $layup->id, 404);
+
+        $layer->delete();
+
+        return redirect()->route('suppliers.layups.layers.index', [$supplier, $layup])->with('status', 'Layer deleted.');
+    }
+}

--- a/app/Http/Controllers/CltLayupController.php
+++ b/app/Http/Controllers/CltLayupController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCltLayupRequest;
+use App\Http\Requests\UpdateCltLayupRequest;
+use App\Models\CltLayup;
+use App\Models\Supplier;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
+
+class CltLayupController extends Controller
+{
+    public function index(Supplier $supplier): View
+    {
+        $this->authorize('view', $supplier);
+
+        $layups = $supplier->cltLayups()->orderBy('name')->withCount('cltLayers')->paginate(15);
+
+        return view('clt_layups.index', compact('supplier', 'layups'));
+    }
+
+    public function create(Supplier $supplier): View
+    {
+        $this->authorize('update', $supplier);
+
+        return view('clt_layups.create', compact('supplier'));
+    }
+
+    public function store(StoreCltLayupRequest $request, Supplier $supplier): RedirectResponse
+    {
+        $this->authorize('update', $supplier);
+
+        $data = $request->validated();
+        if ($supplier->cltLayups()->where('name', $data['name'])->exists()) {
+            throw ValidationException::withMessages(['name' => 'A layup with this name already exists for this supplier.']);
+        }
+
+        $layup = $supplier->cltLayups()->create($data);
+
+        return redirect()->route('suppliers.layups.show', [$supplier, $layup])->with('status', 'Layup created.');
+    }
+
+    public function show(Supplier $supplier, CltLayup $layup): View
+    {
+        $this->authorize('view', $supplier);
+        $this->authorize('view', $layup);
+
+        abort_unless($layup->supplier_id === $supplier->id, 404);
+
+        $layup->load('cltLayers');
+
+        return view('clt_layups.show', compact('supplier', 'layup'));
+    }
+
+    public function edit(Supplier $supplier, CltLayup $layup): View
+    {
+        $this->authorize('update', $supplier);
+        $this->authorize('update', $layup);
+
+        abort_unless($layup->supplier_id === $supplier->id, 404);
+
+        return view('clt_layups.edit', compact('supplier', 'layup'));
+    }
+
+    public function update(UpdateCltLayupRequest $request, Supplier $supplier, CltLayup $layup): RedirectResponse
+    {
+        $this->authorize('update', $supplier);
+        $this->authorize('update', $layup);
+
+        abort_unless($layup->supplier_id === $supplier->id, 404);
+
+        $data = $request->validated();
+        if ($data['name'] !== $layup->name && $supplier->cltLayups()->where('name', $data['name'])->exists()) {
+            throw ValidationException::withMessages(['name' => 'A layup with this name already exists for this supplier.']);
+        }
+
+        $layup->update($data);
+
+        return redirect()->route('suppliers.layups.show', [$supplier, $layup])->with('status', 'Layup updated.');
+    }
+
+    public function destroy(Supplier $supplier, CltLayup $layup): RedirectResponse
+    {
+        $this->authorize('update', $supplier);
+        $this->authorize('delete', $layup);
+
+        abort_unless($layup->supplier_id === $supplier->id, 404);
+
+        $layup->delete();
+
+        return redirect()->route('suppliers.layups.index', $supplier)->with('status', 'Layup deleted.');
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests;
 }

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Exceptions\ImportConflictException;
+use App\Http\Requests\ImportSupplierRequest;
+use App\Http\Requests\StoreSupplierRequest;
+use App\Http\Requests\UpdateSupplierRequest;
+use App\Models\Supplier;
+use App\Services\SupplierImportExportService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
+use Illuminate\View\View;
+
+class SupplierController extends Controller
+{
+    public function index(): View
+    {
+        $this->authorize('viewAny', Supplier::class);
+
+        $suppliers = Supplier::query()->withCount('cltLayups')->orderBy('name')->paginate(15);
+
+        return view('suppliers.index', compact('suppliers'));
+    }
+
+    public function create(): View
+    {
+        $this->authorize('create', Supplier::class);
+
+        return view('suppliers.create');
+    }
+
+    public function store(StoreSupplierRequest $request): RedirectResponse
+    {
+        $supplier = Supplier::create($request->validated());
+
+        return redirect()->route('suppliers.show', $supplier)->with('status', 'Supplier created.');
+    }
+
+    public function show(Supplier $supplier): View
+    {
+        $this->authorize('view', $supplier);
+
+        $supplier->load(['cltLayups' => fn ($q) => $q->orderBy('name')->withCount('cltLayers')]);
+
+        return view('suppliers.show', compact('supplier'));
+    }
+
+    public function edit(Supplier $supplier): View
+    {
+        $this->authorize('update', $supplier);
+
+        return view('suppliers.edit', compact('supplier'));
+    }
+
+    public function update(UpdateSupplierRequest $request, Supplier $supplier): RedirectResponse
+    {
+        $supplier->update($request->validated());
+
+        return redirect()->route('suppliers.show', $supplier)->with('status', 'Supplier updated.');
+    }
+
+    public function destroy(Supplier $supplier): RedirectResponse
+    {
+        $this->authorize('delete', $supplier);
+        $supplier->delete();
+
+        return redirect()->route('suppliers.index')->with('status', 'Supplier deleted.');
+    }
+
+    public function export(Supplier $supplier, SupplierImportExportService $service): Response
+    {
+        $this->authorize('view', $supplier);
+
+        $data = $service->exportPayload($supplier);
+        $filename = 'supplier-'.$supplier->id.'-export.json';
+
+        return response(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), 200, [
+            'Content-Type' => 'application/json; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+        ]);
+    }
+
+    public function importForm(Supplier $supplier): View
+    {
+        $this->authorize('update', $supplier);
+
+        return view('suppliers.import', compact('supplier'));
+    }
+
+    public function import(ImportSupplierRequest $request, Supplier $supplier, SupplierImportExportService $service): RedirectResponse
+    {
+        $this->authorize('update', $supplier);
+
+        $strategy = $request->validated('strategy');
+        $payload = $request->validated('payload');
+
+        try {
+            $result = $service->import($supplier, $payload, $strategy);
+        } catch (ImportConflictException $e) {
+            return redirect()
+                ->route('suppliers.import.form', $supplier)
+                ->withInput()
+                ->withErrors(['import' => 'Conflicts detected (reject strategy).'])
+                ->with('conflicts', $e->conflicts);
+        } catch (\Throwable $e) {
+            return redirect()
+                ->route('suppliers.import.form', $supplier)
+                ->withInput()
+                ->withErrors(['import' => $e->getMessage()]);
+        }
+
+        return redirect()
+            ->route('suppliers.show', $supplier)
+            ->with('status', $result['message'].' Layups created: '.$result['created_layups'].', layers updated: '.$result['updated_layers'].', skipped: '.$result['skipped_layers']);
+    }
+}

--- a/app/Http/Requests/ImportSupplierRequest.php
+++ b/app/Http/Requests/ImportSupplierRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportSupplierRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $raw = $this->input('json_payload');
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $this->merge(['payload' => $decoded]);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'strategy' => ['required', 'in:overwrite,skip,duplicate,reject'],
+            'payload' => ['required', 'array'],
+            'payload.layups' => ['present', 'array'],
+            'json_payload' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreCltLayerRequest.php
+++ b/app/Http/Requests/StoreCltLayerRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCltLayerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'layer_order' => ['required', 'integer', 'min:0'],
+            'thickness' => ['required', 'numeric', 'min:0'],
+            'width' => ['required', 'numeric', 'min:0'],
+            'angle' => ['required', 'numeric'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreCltLayupRequest.php
+++ b/app/Http/Requests/StoreCltLayupRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCltLayupRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreSupplierRequest.php
+++ b/app/Http/Requests/StoreSupplierRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSupplierRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'code' => ['nullable', 'string', 'max:100'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCltLayerRequest.php
+++ b/app/Http/Requests/UpdateCltLayerRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCltLayerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'layer_order' => ['required', 'integer', 'min:0'],
+            'thickness' => ['required', 'numeric', 'min:0'],
+            'width' => ['required', 'numeric', 'min:0'],
+            'angle' => ['required', 'numeric'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCltLayupRequest.php
+++ b/app/Http/Requests/UpdateCltLayupRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCltLayupRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateSupplierRequest.php
+++ b/app/Http/Requests/UpdateSupplierRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSupplierRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'code' => ['nullable', 'string', 'max:100'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Models/CltLayer.php
+++ b/app/Models/CltLayer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CltLayer extends Model
+{
+    protected $fillable = [
+        'clt_layup_id',
+        'layer_order',
+        'thickness',
+        'width',
+        'angle',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'layer_order' => 'integer',
+            'thickness' => 'decimal:3',
+            'width' => 'decimal:3',
+            'angle' => 'decimal:3',
+        ];
+    }
+
+    public function cltLayup(): BelongsTo
+    {
+        return $this->belongsTo(CltLayup::class);
+    }
+}

--- a/app/Models/CltLayup.php
+++ b/app/Models/CltLayup.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class CltLayup extends Model
+{
+    protected $fillable = [
+        'supplier_id',
+        'name',
+        'description',
+    ];
+
+    public function supplier(): BelongsTo
+    {
+        return $this->belongsTo(Supplier::class);
+    }
+
+    public function cltLayers(): HasMany
+    {
+        return $this->hasMany(CltLayer::class)->orderBy('layer_order');
+    }
+}

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Supplier extends Model
+{
+    protected $fillable = [
+        'name',
+        'code',
+        'notes',
+    ];
+
+    public function cltLayups(): HasMany
+    {
+        return $this->hasMany(CltLayup::class);
+    }
+}

--- a/app/Policies/CltLayerPolicy.php
+++ b/app/Policies/CltLayerPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CltLayer;
+use App\Models\User;
+
+class CltLayerPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, CltLayer $cltLayer): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, CltLayer $cltLayer): bool
+    {
+        return true;
+    }
+
+    public function delete(User $user, CltLayer $cltLayer): bool
+    {
+        return true;
+    }
+}

--- a/app/Policies/CltLayupPolicy.php
+++ b/app/Policies/CltLayupPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CltLayup;
+use App\Models\User;
+
+class CltLayupPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, CltLayup $cltLayup): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, CltLayup $cltLayup): bool
+    {
+        return true;
+    }
+
+    public function delete(User $user, CltLayup $cltLayup): bool
+    {
+        return true;
+    }
+}

--- a/app/Policies/SupplierPolicy.php
+++ b/app/Policies/SupplierPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Supplier;
+use App\Models\User;
+
+class SupplierPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Supplier $supplier): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Supplier $supplier): bool
+    {
+        return true;
+    }
+
+    public function delete(User $user, Supplier $supplier): bool
+    {
+        return true;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,14 @@
 
 namespace App\Providers;
 
+use App\Models\CltLayer;
+use App\Models\CltLayup;
+use App\Models\Supplier;
+use App\Policies\CltLayerPolicy;
+use App\Policies\CltLayupPolicy;
+use App\Policies\SupplierPolicy;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +27,30 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::policy(Supplier::class, SupplierPolicy::class);
+        Gate::policy(CltLayup::class, CltLayupPolicy::class);
+        Gate::policy(CltLayer::class, CltLayerPolicy::class);
+
+        Route::bind('layup', function (string $value, $route) {
+            $supplier = $route->parameter('supplier');
+            if (! $supplier instanceof Supplier) {
+                $supplier = Supplier::findOrFail($supplier);
+            }
+
+            return CltLayup::where('supplier_id', $supplier->id)
+                ->where('id', $value)
+                ->firstOrFail();
+        });
+
+        Route::bind('layer', function (string $value, $route) {
+            $layup = $route->parameter('layup');
+            if (! $layup instanceof CltLayup) {
+                $layup = CltLayup::findOrFail($layup);
+            }
+
+            return CltLayer::where('clt_layup_id', $layup->id)
+                ->where('id', $value)
+                ->firstOrFail();
+        });
     }
 }

--- a/app/Services/SupplierImportExportService.php
+++ b/app/Services/SupplierImportExportService.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\ImportConflictException;
+use App\Models\CltLayer;
+use App\Models\CltLayup;
+use App\Models\Supplier;
+use Illuminate\Support\Facades\DB;
+
+class SupplierImportExportService
+{
+    /** @return array<string, mixed> */
+    public function exportPayload(Supplier $supplier): array
+    {
+        $supplier->load(['cltLayups.cltLayers']);
+
+        return [
+            'supplier' => [
+                'name' => $supplier->name,
+                'code' => $supplier->code,
+                'notes' => $supplier->notes,
+            ],
+            'layups' => $supplier->cltLayups->map(function (CltLayup $layup) {
+                return [
+                    'name' => $layup->name,
+                    'description' => $layup->description,
+                    'layers' => $layup->cltLayers->map(fn (CltLayer $l) => [
+                        'layer_order' => $l->layer_order,
+                        'thickness' => (float) $l->thickness,
+                        'width' => (float) $l->width,
+                        'angle' => (float) $l->angle,
+                    ])->values()->all(),
+                ];
+            })->values()->all(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload  Must contain 'layups' array
+     * @return array{created_layups: int, updated_layers: int, skipped_layers: int, message: string}
+     */
+    public function import(Supplier $supplier, array $payload, string $strategy = 'overwrite'): array
+    {
+        $layupsIn = $payload['layups'] ?? null;
+        if (! is_array($layupsIn)) {
+            throw new \InvalidArgumentException('Invalid import: "layups" must be an array.');
+        }
+
+        if ($strategy === 'reject') {
+            $conflicts = $this->collectLayerConflicts($supplier, $layupsIn);
+            if (count($conflicts) > 0) {
+                throw new ImportConflictException($conflicts);
+            }
+        }
+
+        $createdLayups = 0;
+        $updatedLayers = 0;
+        $skippedLayers = 0;
+
+        DB::transaction(function () use ($supplier, $layupsIn, $strategy, &$createdLayups, &$updatedLayers, &$skippedLayers) {
+            foreach ($layupsIn as $layupData) {
+                $name = $layupData['name'] ?? null;
+                if (! is_string($name) || $name === '') {
+                    continue;
+                }
+
+                $existing = CltLayup::where('supplier_id', $supplier->id)->where('name', $name)->first();
+
+                if ($existing && $strategy === 'duplicate') {
+                    $newName = $this->uniqueImportedLayupName($supplier, $name);
+                    $layup = CltLayup::create([
+                        'supplier_id' => $supplier->id,
+                        'name' => $newName,
+                        'description' => $layupData['description'] ?? null,
+                    ]);
+                    $createdLayups++;
+                    $this->importLayers($layup, $layupData['layers'] ?? [], 'overwrite', $updatedLayers, $skippedLayers);
+                } elseif ($existing) {
+                    $layup = $existing;
+                    if (isset($layupData['description'])) {
+                        $layup->update(['description' => $layupData['description']]);
+                    }
+                    $layerStrategy = in_array($strategy, ['reject', 'duplicate'], true) ? 'overwrite' : $strategy;
+                    $this->importLayers($layup, $layupData['layers'] ?? [], $layerStrategy, $updatedLayers, $skippedLayers);
+                } else {
+                    $layup = CltLayup::create([
+                        'supplier_id' => $supplier->id,
+                        'name' => $name,
+                        'description' => $layupData['description'] ?? null,
+                    ]);
+                    $createdLayups++;
+                    $this->importLayers($layup, $layupData['layers'] ?? [], 'overwrite', $updatedLayers, $skippedLayers);
+                }
+            }
+        });
+
+        return [
+            'created_layups' => $createdLayups,
+            'updated_layers' => $updatedLayers,
+            'skipped_layers' => $skippedLayers,
+            'message' => 'Import completed.',
+        ];
+    }
+
+    private function uniqueImportedLayupName(Supplier $supplier, string $original): string
+    {
+        $base = $original.' (imported)';
+        $name = $base;
+        $i = 2;
+        while (CltLayup::where('supplier_id', $supplier->id)->where('name', $name)->exists()) {
+            $name = $original.' (imported '.$i.')';
+            $i++;
+        }
+
+        return $name;
+    }
+
+    /**
+     * @param  array<int, mixed>  $layersIn
+     */
+    private function importLayers(
+        CltLayup $layup,
+        array $layersIn,
+        string $strategy,
+        int &$updatedLayers,
+        int &$skippedLayers
+    ): void {
+        foreach ($layersIn as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $order = isset($row['layer_order']) ? (int) $row['layer_order'] : null;
+            if ($order === null || $order < 0) {
+                continue;
+            }
+
+            $thickness = (float) ($row['thickness'] ?? 0);
+            $width = (float) ($row['width'] ?? 0);
+            $angle = (float) ($row['angle'] ?? 0);
+
+            $existing = CltLayer::where('clt_layup_id', $layup->id)->where('layer_order', $order)->first();
+
+            if (! $existing) {
+                CltLayer::create([
+                    'clt_layup_id' => $layup->id,
+                    'layer_order' => $order,
+                    'thickness' => $thickness,
+                    'width' => $width,
+                    'angle' => $angle,
+                ]);
+                $updatedLayers++;
+
+                continue;
+            }
+
+            $same = $this->floatEq($existing->thickness, $thickness)
+                && $this->floatEq($existing->width, $width)
+                && $this->floatEq($existing->angle, $angle);
+
+            if ($same) {
+                continue;
+            }
+
+            if ($strategy === 'overwrite') {
+                $existing->update([
+                    'thickness' => $thickness,
+                    'width' => $width,
+                    'angle' => $angle,
+                ]);
+                $updatedLayers++;
+            } elseif ($strategy === 'skip') {
+                $skippedLayers++;
+            }
+        }
+    }
+
+    private function floatEq(float|string $a, float $b, float $eps = 0.0001): bool
+    {
+        return abs((float) $a - $b) < $eps;
+    }
+
+    /**
+     * Layer-level conflicts: same layer_order, different fields.
+     *
+     * @param  array<int, mixed>  $layupsIn
+     * @return list<array<string, mixed>>
+     */
+    public function collectLayerConflicts(Supplier $supplier, array $layupsIn): array
+    {
+        $out = [];
+
+        foreach ($layupsIn as $layupData) {
+            $name = $layupData['name'] ?? null;
+            if (! is_string($name) || $name === '') {
+                continue;
+            }
+
+            $layup = CltLayup::where('supplier_id', $supplier->id)->where('name', $name)->first();
+            if (! $layup) {
+                continue;
+            }
+
+            foreach ($layupData['layers'] ?? [] as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+                $order = isset($row['layer_order']) ? (int) $row['layer_order'] : null;
+                if ($order === null) {
+                    continue;
+                }
+
+                $existing = CltLayer::where('clt_layup_id', $layup->id)->where('layer_order', $order)->first();
+                if (! $existing) {
+                    continue;
+                }
+
+                $thickness = (float) ($row['thickness'] ?? 0);
+                $width = (float) ($row['width'] ?? 0);
+                $angle = (float) ($row['angle'] ?? 0);
+
+                if (
+                    $this->floatEq($existing->thickness, $thickness)
+                    && $this->floatEq($existing->width, $width)
+                    && $this->floatEq($existing->angle, $angle)
+                ) {
+                    continue;
+                }
+
+                $out[] = [
+                    'layup' => $name,
+                    'layer_order' => $order,
+                    'existing' => [
+                        'thickness' => (float) $existing->thickness,
+                        'width' => (float) $existing->width,
+                        'angle' => (float) $existing->angle,
+                    ],
+                    'incoming' => [
+                        'thickness' => $thickness,
+                        'width' => $width,
+                        'angle' => $angle,
+                    ],
+                ];
+            }
+        }
+
+        return $out;
+    }
+}

--- a/database/migrations/2026_04_19_100000_create_suppliers_clt_layups_clt_layers_tables.php
+++ b/database/migrations/2026_04_19_100000_create_suppliers_clt_layups_clt_layers_tables.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('suppliers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('code')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('clt_layups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('supplier_id')->constrained('suppliers')->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+
+            $table->unique(['supplier_id', 'name']);
+        });
+
+        Schema::create('clt_layers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('clt_layup_id')->constrained('clt_layups')->cascadeOnDelete();
+            $table->unsignedInteger('layer_order');
+            $table->decimal('thickness', 12, 3);
+            $table->decimal('width', 12, 3);
+            $table->decimal('angle', 10, 3);
+            $table->timestamps();
+
+            $table->unique(['clt_layup_id', 'layer_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clt_layers');
+        Schema::dropIfExists('clt_layups');
+        Schema::dropIfExists('suppliers');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/views/clt_layers/create.blade.php
+++ b/resources/views/clt_layers/create.blade.php
@@ -1,0 +1,37 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('New layer') }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="post" action="{{ route('suppliers.layups.layers.store', [$supplier, $layup]) }}" class="space-y-4">
+                    @csrf
+                    <div>
+                        <x-input-label for="layer_order" :value="__('Layer order')" />
+                        <x-text-input id="layer_order" name="layer_order" type="number" min="0" class="mt-1 block w-full" :value="old('layer_order')" required />
+                        <x-input-error :messages="$errors->get('layer_order')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="thickness" :value="__('Thickness')" />
+                        <x-text-input id="thickness" name="thickness" type="text" class="mt-1 block w-full" :value="old('thickness')" required />
+                        <x-input-error :messages="$errors->get('thickness')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="width" :value="__('Width')" />
+                        <x-text-input id="width" name="width" type="text" class="mt-1 block w-full" :value="old('width')" required />
+                    </div>
+                    <div>
+                        <x-input-label for="angle" :value="__('Angle (°)')" />
+                        <x-text-input id="angle" name="angle" type="text" class="mt-1 block w-full" :value="old('angle', '0')" required />
+                    </div>
+                    <div class="flex gap-2">
+                        <x-primary-button>{{ __('Save') }}</x-primary-button>
+                        <a href="{{ route('suppliers.layups.show', [$supplier, $layup]) }}"><x-secondary-button type="button">{{ __('Cancel') }}</x-secondary-button></a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/clt_layers/edit.blade.php
+++ b/resources/views/clt_layers/edit.blade.php
@@ -1,0 +1,37 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('Edit layer') }} #{{ $layer->layer_order }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="post" action="{{ route('suppliers.layups.layers.update', [$supplier, $layup, $layer]) }}" class="space-y-4">
+                    @csrf
+                    @method('patch')
+                    <div>
+                        <x-input-label for="layer_order" :value="__('Layer order')" />
+                        <x-text-input id="layer_order" name="layer_order" type="number" min="0" class="mt-1 block w-full" :value="old('layer_order', $layer->layer_order)" required />
+                        <x-input-error :messages="$errors->get('layer_order')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="thickness" :value="__('Thickness')" />
+                        <x-text-input id="thickness" name="thickness" type="text" class="mt-1 block w-full" :value="old('thickness', $layer->thickness)" required />
+                    </div>
+                    <div>
+                        <x-input-label for="width" :value="__('Width')" />
+                        <x-text-input id="width" name="width" type="text" class="mt-1 block w-full" :value="old('width', $layer->width)" required />
+                    </div>
+                    <div>
+                        <x-input-label for="angle" :value="__('Angle (°)')" />
+                        <x-text-input id="angle" name="angle" type="text" class="mt-1 block w-full" :value="old('angle', $layer->angle)" required />
+                    </div>
+                    <div class="flex gap-2">
+                        <x-primary-button>{{ __('Update') }}</x-primary-button>
+                        <a href="{{ route('suppliers.layups.layers.show', [$supplier, $layup, $layer]) }}"><x-secondary-button type="button">{{ __('Cancel') }}</x-secondary-button></a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/clt_layers/index.blade.php
+++ b/resources/views/clt_layers/index.blade.php
@@ -1,0 +1,47 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                {{ __('Layers') }} — {{ $layup->name }}
+            </h2>
+            <a href="{{ route('suppliers.layups.layers.create', [$supplier, $layup]) }}">
+                <x-primary-button type="button">{{ __('New layer') }}</x-primary-button>
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <table class="min-w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-gray-200 dark:border-gray-600 text-left">
+                            <th class="py-2 pr-4">#</th>
+                            <th class="py-2 pr-4">{{ __('Thickness') }}</th>
+                            <th class="py-2 pr-4">{{ __('Width') }}</th>
+                            <th class="py-2 pr-4">{{ __('Angle') }}</th>
+                            <th class="py-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($layers as $layer)
+                            <tr class="border-b border-gray-100 dark:border-gray-700">
+                                <td class="py-2 pr-4">{{ $layer->layer_order }}</td>
+                                <td class="py-2 pr-4">{{ $layer->thickness }}</td>
+                                <td class="py-2 pr-4">{{ $layer->width }}</td>
+                                <td class="py-2 pr-4">{{ $layer->angle }}</td>
+                                <td class="py-2 text-right">
+                                    <a href="{{ route('suppliers.layups.layers.show', [$supplier, $layup, $layer]) }}" class="text-indigo-600 dark:text-indigo-400">{{ __('View') }}</a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="5" class="py-4">{{ __('No layers.') }}</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+                <div class="mt-4">{{ $layers->links() }}</div>
+                <a href="{{ route('suppliers.layups.show', [$supplier, $layup]) }}" class="text-indigo-600 dark:text-indigo-400 text-sm">{{ __('← Back to layup') }}</a>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/clt_layers/show.blade.php
+++ b/resources/views/clt_layers/show.blade.php
@@ -1,0 +1,28 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('Layer') }} #{{ $layer->layer_order }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6 space-y-2 text-sm">
+                <p><strong>{{ __('Thickness') }}:</strong> {{ $layer->thickness }}</p>
+                <p><strong>{{ __('Width') }}:</strong> {{ $layer->width }}</p>
+                <p><strong>{{ __('Angle') }}:</strong> {{ $layer->angle }}</p>
+            </div>
+            <div class="flex gap-2">
+                <a href="{{ route('suppliers.layups.layers.edit', [$supplier, $layup, $layer]) }}">
+                    <x-primary-button type="button">{{ __('Edit') }}</x-primary-button>
+                </a>
+                <a href="{{ route('suppliers.layups.show', [$supplier, $layup]) }}">
+                    <x-secondary-button type="button">{{ __('Back') }}</x-secondary-button>
+                </a>
+            </div>
+            <form method="post" action="{{ route('suppliers.layups.layers.destroy', [$supplier, $layup, $layer]) }}" onsubmit="return confirm('Delete this layer?');">
+                @csrf
+                @method('delete')
+                <x-danger-button type="submit">{{ __('Delete layer') }}</x-danger-button>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/clt_layups/create.blade.php
+++ b/resources/views/clt_layups/create.blade.php
@@ -1,0 +1,28 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('New layup') }} — {{ $supplier->name }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="post" action="{{ route('suppliers.layups.store', $supplier) }}" class="space-y-4">
+                    @csrf
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name')" required />
+                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="description" :value="__('Description')" />
+                        <textarea id="description" name="description" rows="3" class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 rounded-md shadow-sm">{{ old('description') }}</textarea>
+                    </div>
+                    <div class="flex gap-2">
+                        <x-primary-button>{{ __('Save') }}</x-primary-button>
+                        <a href="{{ route('suppliers.show', $supplier) }}"><x-secondary-button type="button">{{ __('Cancel') }}</x-secondary-button></a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/clt_layups/edit.blade.php
+++ b/resources/views/clt_layups/edit.blade.php
@@ -1,0 +1,29 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('Edit layup') }} — {{ $layup->name }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="post" action="{{ route('suppliers.layups.update', [$supplier, $layup]) }}" class="space-y-4">
+                    @csrf
+                    @method('patch')
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $layup->name)" required />
+                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="description" :value="__('Description')" />
+                        <textarea id="description" name="description" rows="3" class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 rounded-md shadow-sm">{{ old('description', $layup->description) }}</textarea>
+                    </div>
+                    <div class="flex gap-2">
+                        <x-primary-button>{{ __('Update') }}</x-primary-button>
+                        <a href="{{ route('suppliers.layups.show', [$supplier, $layup]) }}"><x-secondary-button type="button">{{ __('Cancel') }}</x-secondary-button></a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/clt_layups/index.blade.php
+++ b/resources/views/clt_layups/index.blade.php
@@ -1,0 +1,43 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                <a href="{{ route('suppliers.show', $supplier) }}" class="text-indigo-600 dark:text-indigo-400">{{ $supplier->name }}</a>
+                <span class="text-gray-400"> / </span> {{ __('Layups') }}
+            </h2>
+            <a href="{{ route('suppliers.layups.create', $supplier) }}">
+                <x-primary-button type="button">{{ __('New layup') }}</x-primary-button>
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <table class="min-w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-gray-200 dark:border-gray-600 text-left">
+                            <th class="py-2 pr-4">{{ __('Name') }}</th>
+                            <th class="py-2 pr-4">{{ __('Layers') }}</th>
+                            <th class="py-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($layups as $layup)
+                            <tr class="border-b border-gray-100 dark:border-gray-700">
+                                <td class="py-2 pr-4">{{ $layup->name }}</td>
+                                <td class="py-2 pr-4">{{ $layup->clt_layers_count }}</td>
+                                <td class="py-2 text-right">
+                                    <a href="{{ route('suppliers.layups.show', [$supplier, $layup]) }}" class="text-indigo-600 dark:text-indigo-400">{{ __('Open') }}</a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="3" class="py-4">{{ __('No layups.') }}</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+                <div class="mt-4">{{ $layups->links() }}</div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/clt_layups/show.blade.php
+++ b/resources/views/clt_layups/show.blade.php
@@ -1,0 +1,65 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex flex-wrap justify-between items-center gap-2">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ $layup->name }}</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="{{ route('suppliers.layups.layers.create', [$supplier, $layup]) }}">
+                    <x-primary-button type="button">{{ __('New layer') }}</x-primary-button>
+                </a>
+                <a href="{{ route('suppliers.layups.layers.index', [$supplier, $layup]) }}">
+                    <x-secondary-button type="button">{{ __('List layers') }}</x-secondary-button>
+                </a>
+                <a href="{{ route('suppliers.layups.edit', [$supplier, $layup]) }}">
+                    <x-secondary-button type="button">{{ __('Edit layup') }}</x-secondary-button>
+                </a>
+            </div>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            @if (session('status'))
+                <p class="text-green-600 dark:text-green-400">{{ session('status') }}</p>
+            @endif
+
+            <p class="text-sm text-gray-600 dark:text-gray-300"><a href="{{ route('suppliers.show', $supplier) }}" class="text-indigo-600">{{ $supplier->name }}</a></p>
+            <p class="text-sm">{{ $layup->description ?? '—' }}</p>
+
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <h3 class="text-lg font-medium mb-4">{{ __('Layers') }}</h3>
+                <table class="min-w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-gray-200 dark:border-gray-600 text-left">
+                            <th class="py-2 pr-4">#</th>
+                            <th class="py-2 pr-4">{{ __('Thickness') }}</th>
+                            <th class="py-2 pr-4">{{ __('Width') }}</th>
+                            <th class="py-2 pr-4">{{ __('Angle') }}</th>
+                            <th class="py-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($layup->cltLayers as $layer)
+                            <tr class="border-b border-gray-100 dark:border-gray-700">
+                                <td class="py-2 pr-4">{{ $layer->layer_order }}</td>
+                                <td class="py-2 pr-4">{{ $layer->thickness }}</td>
+                                <td class="py-2 pr-4">{{ $layer->width }}</td>
+                                <td class="py-2 pr-4">{{ $layer->angle }}</td>
+                                <td class="py-2 text-right">
+                                    <a href="{{ route('suppliers.layups.layers.edit', [$supplier, $layup, $layer]) }}" class="text-indigo-600 dark:text-indigo-400">{{ __('Edit') }}</a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="5" class="py-4">{{ __('No layers yet.') }}</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            <form method="post" action="{{ route('suppliers.layups.destroy', [$supplier, $layup]) }}" onsubmit="return confirm('Delete this layup and all layers?');">
+                @csrf
+                @method('delete')
+                <x-danger-button type="submit">{{ __('Delete layup') }}</x-danger-button>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,9 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('suppliers.index')" :active="request()->routeIs('suppliers.*')">
+                        {{ __('Suppliers') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -69,6 +72,9 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('suppliers.index')" :active="request()->routeIs('suppliers.*')">
+                {{ __('Suppliers') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/suppliers/create.blade.php
+++ b/resources/views/suppliers/create.blade.php
@@ -1,0 +1,34 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('New supplier') }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="post" action="{{ route('suppliers.store') }}" class="space-y-4">
+                    @csrf
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name')" required />
+                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="code" :value="__('Code')" />
+                        <x-text-input id="code" name="code" type="text" class="mt-1 block w-full" :value="old('code')" />
+                        <x-input-error :messages="$errors->get('code')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="notes" :value="__('Notes')" />
+                        <textarea id="notes" name="notes" rows="3" class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 rounded-md shadow-sm">{{ old('notes') }}</textarea>
+                        <x-input-error :messages="$errors->get('notes')" class="mt-2" />
+                    </div>
+                    <div class="flex gap-2">
+                        <x-primary-button>{{ __('Save') }}</x-primary-button>
+                        <a href="{{ route('suppliers.index') }}" class="inline-flex items-center px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 rounded-md">{{ __('Cancel') }}</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -1,0 +1,34 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('Edit supplier') }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="post" action="{{ route('suppliers.update', $supplier) }}" class="space-y-4">
+                    @csrf
+                    @method('patch')
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $supplier->name)" required />
+                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="code" :value="__('Code')" />
+                        <x-text-input id="code" name="code" type="text" class="mt-1 block w-full" :value="old('code', $supplier->code)" />
+                        <x-input-error :messages="$errors->get('code')" class="mt-2" />
+                    </div>
+                    <div>
+                        <x-input-label for="notes" :value="__('Notes')" />
+                        <textarea id="notes" name="notes" rows="3" class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 rounded-md shadow-sm">{{ old('notes', $supplier->notes) }}</textarea>
+                    </div>
+                    <div class="flex gap-2">
+                        <x-primary-button>{{ __('Update') }}</x-primary-button>
+                        <a href="{{ route('suppliers.show', $supplier) }}" class="inline-flex items-center px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 rounded-md">{{ __('Cancel') }}</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/suppliers/import.blade.php
+++ b/resources/views/suppliers/import.blade.php
@@ -1,0 +1,50 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('Import JSON') }} — {{ $supplier->name }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
+                    {{ __('Paste JSON with structure: { "layups": [ { "name", "description", "layers": [ { "layer_order", "thickness", "width", "angle" } ] } ] }. Strategy applies to layup/layer conflicts per skill test readme.') }}
+                </p>
+
+                @if ($errors->has('import'))
+                    <p class="text-red-600 dark:text-red-400 mb-2">{{ $errors->first('import') }}</p>
+                @endif
+
+                @if (session('conflicts'))
+                    <div class="mb-4 p-4 bg-red-50 dark:bg-red-900/20 rounded text-sm overflow-x-auto">
+                        <pre class="whitespace-pre-wrap">{{ json_encode(session('conflicts'), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) }}</pre>
+                    </div>
+                @endif
+
+                <form method="post" action="{{ route('suppliers.import', $supplier) }}" class="space-y-4">
+                    @csrf
+                    <div>
+                        <x-input-label for="strategy" :value="__('Conflict strategy')" />
+                        <select id="strategy" name="strategy" class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 rounded-md shadow-sm" required>
+                            <option value="overwrite" @selected(old('strategy') === 'overwrite')>{{ __('Overwrite existing') }}</option>
+                            <option value="skip" @selected(old('strategy') === 'skip')>{{ __('Skip conflicting layers') }}</option>
+                            <option value="duplicate" @selected(old('strategy') === 'duplicate')>{{ __('Duplicate layup (imported)') }}</option>
+                            <option value="reject" @selected(old('strategy') === 'reject')>{{ __('Reject entire import on conflict') }}</option>
+                        </select>
+                    </div>
+                    <div>
+                        <x-input-label for="json_payload" :value="__('JSON payload')" />
+                        <textarea id="json_payload" name="json_payload" rows="16" class="mt-1 block w-full font-mono text-sm border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 rounded-md shadow-sm" required>{{ old('json_payload', '{"layups":[]}') }}</textarea>
+                        <x-input-error :messages="$errors->get('json_payload')" class="mt-2" />
+                        <x-input-error :messages="$errors->get('payload')" class="mt-2" />
+                    </div>
+                    <div class="flex gap-2">
+                        <x-primary-button>{{ __('Run import') }}</x-primary-button>
+                        <a href="{{ route('suppliers.show', $supplier) }}">
+                            <x-secondary-button type="button">{{ __('Cancel') }}</x-secondary-button>
+                        </a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/suppliers/index.blade.php
+++ b/resources/views/suppliers/index.blade.php
@@ -1,0 +1,48 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ __('Suppliers') }}</h2>
+            <a href="{{ route('suppliers.create') }}">
+                <x-primary-button type="button">{{ __('New supplier') }}</x-primary-button>
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @if (session('status'))
+                <p class="mb-4 text-green-600 dark:text-green-400">{{ session('status') }}</p>
+            @endif
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <table class="min-w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-gray-200 dark:border-gray-600 text-left">
+                                <th class="py-2 pr-4">{{ __('Name') }}</th>
+                                <th class="py-2 pr-4">{{ __('Code') }}</th>
+                                <th class="py-2 pr-4">{{ __('Layups') }}</th>
+                                <th class="py-2"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($suppliers as $supplier)
+                                <tr class="border-b border-gray-100 dark:border-gray-700">
+                                    <td class="py-2 pr-4">{{ $supplier->name }}</td>
+                                    <td class="py-2 pr-4">{{ $supplier->code ?? '—' }}</td>
+                                    <td class="py-2 pr-4">{{ $supplier->clt_layups_count }}</td>
+                                    <td class="py-2 text-right space-x-2">
+                                        <a href="{{ route('suppliers.show', $supplier) }}" class="text-indigo-600 dark:text-indigo-400">{{ __('View') }}</a>
+                                        <a href="{{ route('suppliers.edit', $supplier) }}" class="text-indigo-600 dark:text-indigo-400">{{ __('Edit') }}</a>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr><td colspan="4" class="py-4">{{ __('No suppliers yet.') }}</td></tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                    <div class="mt-4">{{ $suppliers->links() }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/suppliers/show.blade.php
+++ b/resources/views/suppliers/show.blade.php
@@ -1,0 +1,68 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex flex-wrap justify-between items-center gap-2">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{{ $supplier->name }}</h2>
+            <div class="flex flex-wrap gap-2">
+                <a href="{{ route('suppliers.layups.create', $supplier) }}">
+                    <x-primary-button type="button">{{ __('New layup') }}</x-primary-button>
+                </a>
+                <a href="{{ route('suppliers.export', $supplier) }}">
+                    <x-secondary-button type="button">{{ __('Export JSON') }}</x-secondary-button>
+                </a>
+                <a href="{{ route('suppliers.import.form', $supplier) }}">
+                    <x-secondary-button type="button">{{ __('Import') }}</x-secondary-button>
+                </a>
+                <a href="{{ route('suppliers.edit', $supplier) }}">
+                    <x-secondary-button type="button">{{ __('Edit supplier') }}</x-secondary-button>
+                </a>
+            </div>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            @if (session('status'))
+                <p class="text-green-600 dark:text-green-400">{{ session('status') }}</p>
+            @endif
+
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p class="text-sm text-gray-600 dark:text-gray-300"><strong>{{ __('Code') }}:</strong> {{ $supplier->code ?? '—' }}</p>
+                <p class="text-sm text-gray-600 dark:text-gray-300 mt-2"><strong>{{ __('Notes') }}:</strong> {{ $supplier->notes ?? '—' }}</p>
+            </div>
+
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <h3 class="text-lg font-medium mb-4">{{ __('CLT Layups') }}</h3>
+                    <table class="min-w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-gray-200 dark:border-gray-600 text-left">
+                                <th class="py-2 pr-4">{{ __('Name') }}</th>
+                                <th class="py-2 pr-4">{{ __('Layers') }}</th>
+                                <th class="py-2"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($supplier->cltLayups as $layup)
+                                <tr class="border-b border-gray-100 dark:border-gray-700">
+                                    <td class="py-2 pr-4">{{ $layup->name }}</td>
+                                    <td class="py-2 pr-4">{{ $layup->clt_layers_count }}</td>
+                                    <td class="py-2 text-right">
+                                        <a href="{{ route('suppliers.layups.show', [$supplier, $layup]) }}" class="text-indigo-600 dark:text-indigo-400">{{ __('Open') }}</a>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr><td colspan="3" class="py-4">{{ __('No layups yet.') }}</td></tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <form method="post" action="{{ route('suppliers.destroy', $supplier) }}" onsubmit="return confirm('Delete this supplier and all layups/layers?');">
+                @csrf
+                @method('delete')
+                <x-danger-button type="submit">{{ __('Delete supplier') }}</x-danger-button>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Http\Controllers\CltLayerController;
+use App\Http\Controllers\CltLayupController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\SupplierController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -15,6 +18,17 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+});
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('suppliers/{supplier}/export', [SupplierController::class, 'export'])->name('suppliers.export');
+    Route::get('suppliers/{supplier}/import', [SupplierController::class, 'importForm'])->name('suppliers.import.form');
+    Route::post('suppliers/{supplier}/import', [SupplierController::class, 'import'])->name('suppliers.import');
+
+    Route::resource('suppliers', SupplierController::class);
+
+    Route::resource('suppliers.layups', CltLayupController::class);
+    Route::resource('suppliers.layups.layers', CltLayerController::class);
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/SupplierCrudTest.php
+++ b/tests/Feature/SupplierCrudTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Supplier;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SupplierCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_view_suppliers(): void
+    {
+        $this->get(route('suppliers.index'))->assertRedirect(route('login'));
+    }
+
+    public function test_authenticated_user_can_create_and_view_supplier(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('suppliers.store'), [
+                'name' => 'ACME Timber',
+                'code' => 'ACME',
+                'notes' => 'Test',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('suppliers', [
+            'name' => 'ACME Timber',
+            'code' => 'ACME',
+        ]);
+
+        $supplier = Supplier::where('name', 'ACME Timber')->first();
+        $this->assertNotNull($supplier);
+
+        $this->actingAs($user)
+            ->get(route('suppliers.show', $supplier))
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
Implementasi tes backend feature-test: CRUD Supplier -> CLT Layup -> CLT Layer, serta export/import JSON dengan strategi konflik.

Yang diimplementasikan :
- CRUD bersarang untuk supplier, layup, dan layer (policies, form requests, route scoped).
- Export data supplier beserta layup & layer ke JSON.
- Import JSON dengan strategi: `overwrite`, `skip`, `duplicate` (nama layup `(imported)`), `reject` (gagal jika ada konflik layer).
- Migrasi database, view Blade, navigasi Suppliers, serta feature test PHPUnit (SQLite in-memory).

Verifikasi
```bash
composer install
cp .env.example .env && php artisan key:generate
php artisan migrate
php artisan test